### PR TITLE
wasm-engines - mount container files at runtime instead of copying them during build

### DIFF
--- a/wasm-engines/Dockerfile
+++ b/wasm-engines/Dockerfile
@@ -193,22 +193,12 @@ RUN rustup target add wasm32-unknown-unknown
 
 # copy benchmarking scripts
 RUN mkdir /benchrunner
-COPY project /benchrunner/project
 COPY main.py /benchrunner
 COPY wamr_aot.sh /engines/wasm-micro-runtime/
 COPY fizzy.sh /engines/fizzy/
 
 # copy scripts to generate standalone wasm modules
 RUN mkdir /benchprep
-COPY benchnativerust_prepwasm.py /benchprep
-COPY nanodurationpy.py /benchprep
-COPY rust-code /benchprep/rust-code
-COPY inputvectors /benchprep/inputvectors
-COPY benchmeteredstandalone.sh /benchprep
-RUN chmod +x /benchprep/benchmeteredstandalone.sh
-COPY bench_wasm_and_native.sh /benchprep
-RUN chmod +x /benchprep/bench_wasm_and_native.sh
-
 
 RUN mkdir -p /benchmark_results_data
 

--- a/wasm-engines/bench_wasm_and_native.sh
+++ b/wasm-engines/bench_wasm_and_native.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # first compile standalone wasm files from rust code, and benchmark native rust
 # later, benchmark the standalone wasm files in all the wasm engines
 
@@ -59,5 +61,9 @@ done
 
 # benchmark standalone wasm files in all the engines
 
+echo "running benchmarks"
 cd /benchrunner
 python3.7 main.py --wasmdir="${WASM_MINIFIED_DIR}" --csvfile="${CSV_WASM_RESULTS}" |& tee wasm-engines-run1.log
+
+# Reset the uid/gid of files modified to that of the user who is invoking the container. (TODO don't hardcode gid/uid)
+chown -R 1000:1000 /benchrunner /benchprep /benchmark_results_data

--- a/wasm-engines/run_benchmarks.sh
+++ b/wasm-engines/run_benchmarks.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+docker run --privileged \
+	-v $(pwd)/project:/benchrunner/project \
+	-v $(pwd)/main.py:/benchrunner/main.py \
+	-v $(pwd)/benchnativerust_prepwasm.py:/benchprep/benchnativerust_prepwasm.py \
+	-v $(pwd)/wasmfiles:/wasmfiles \
+	-v $(pwd)/benchmark_results_data:/benchmark_results_data \
+	-v $(pwd)/nanodurationpy.py:/benchprep/nanodurationpy.py \
+	-v $(pwd)/rust-code:/benchprep/rust-code \
+	-v $(pwd)/inputvectors:/benchprep/inputvectors \
+	-v $(pwd)/benchmeteredstandalone.sh:/benchprep/benchmeteredstandalone.sh \
+	-v $(pwd)/bench_wasm_and_native.sh:/benchprep/bench_wasm_and_native.sh \
+--security-opt seccomp=$(pwd)/dockerseccompprofile.json -it wasm-engines bash /benchprep/bench_wasm_and_native.sh


### PR DESCRIPTION
Also resets the UID/GID of created/modified files to the invoking user's (currently hardcoded to be 1000/1000).  Otherwise when the container is run (as root inside the container), it will  leave the ownership of files that are created/modified as root.