### PR TITLE
wasm-engines:  terminate benchmarking if a benchmark fails to build

### DIFF
--- a/wasm-engines/Dockerfile
+++ b/wasm-engines/Dockerfile
@@ -193,22 +193,12 @@ RUN rustup target add wasm32-unknown-unknown
 
 # copy benchmarking scripts
 RUN mkdir /benchrunner
-COPY project /benchrunner/project
 COPY main.py /benchrunner
 COPY wamr_aot.sh /engines/wasm-micro-runtime/
 COPY fizzy.sh /engines/fizzy/
 
 # copy scripts to generate standalone wasm modules
 RUN mkdir /benchprep
-COPY benchnativerust_prepwasm.py /benchprep
-COPY nanodurationpy.py /benchprep
-COPY rust-code /benchprep/rust-code
-COPY inputvectors /benchprep/inputvectors
-COPY benchmeteredstandalone.sh /benchprep
-RUN chmod +x /benchprep/benchmeteredstandalone.sh
-COPY bench_wasm_and_native.sh /benchprep
-RUN chmod +x /benchprep/bench_wasm_and_native.sh
-
 
 RUN mkdir -p /benchmark_results_data
 

--- a/wasm-engines/bench_wasm_and_native.sh
+++ b/wasm-engines/bench_wasm_and_native.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 # first compile standalone wasm files from rust code, and benchmark native rust
 # later, benchmark the standalone wasm files in all the wasm engines

--- a/wasm-engines/bench_wasm_and_native.sh
+++ b/wasm-engines/bench_wasm_and_native.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # first compile standalone wasm files from rust code, and benchmark native rust
 # later, benchmark the standalone wasm files in all the wasm engines
 
@@ -59,5 +61,9 @@ done
 
 # benchmark standalone wasm files in all the engines
 
+echo "running benchmarks"
 cd /benchrunner
 python3.7 main.py --wasmdir="${WASM_MINIFIED_DIR}" --csvfile="${CSV_WASM_RESULTS}" |& tee wasm-engines-run1.log
+
+# Reset the uid/gid of files modified to that of the user who is invoking the container. (TODO don't hardcode gid/uid)
+chown -R 1000:1000 /benchrunner /benchprep /benchmark_results_data

--- a/wasm-engines/benchnativerust_prepwasm.py
+++ b/wasm-engines/benchnativerust_prepwasm.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import glob
 import argparse
+import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--wasmoutdir', help='full path of dir containing wasm files')
@@ -95,9 +96,13 @@ def do_rust_bench(benchname, input, rust_code_dir, wasm_out_dir):
     rust_native_cmd = "cargo build --release --bin {}_native".format(benchname_rust)
     print("compiling rust native {}...\n{}".format(input['name'], rust_native_cmd))
     rust_process = subprocess.Popen(rust_native_cmd, cwd=filldir, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
-    rust_process.wait(None)
+    return_code = rust_process.wait(None)
+
     stdoutlines = [str(line, 'utf8') for line in rust_process.stdout]
     print(("").join(stdoutlines), end="")
+    if return_code != 0:
+        sys.exit(-1)
+
     # native binary is at ./target/release/sha1_native
     exec_path = "{}/target/release/{}_native".format(filldir, benchname_rust)
     exec_size = os.path.getsize(exec_path)
@@ -109,9 +114,12 @@ def do_rust_bench(benchname, input, rust_code_dir, wasm_out_dir):
     rust_wasm_cmd = "cargo build --release --lib --target wasm32-unknown-unknown"
     print("compiling rust wasm {}...\n{}".format(input['name'], rust_wasm_cmd))
     rust_process = subprocess.Popen(rust_wasm_cmd, cwd=filldir, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
-    rust_process.wait(None)
+    return_code = rust_process.wait(None)
     stdoutlines = [str(line, 'utf8') for line in rust_process.stdout]
     print(("").join(stdoutlines), end="")
+    if return_code != 0:
+        sys.exit(-1)
+
     # wasm is at ./target/wasm32-unknown-unkown/release/sha1_wasm.wasm
     wasmbin = "{}/target/wasm32-unknown-unknown/release/{}_wasm.wasm".format(filldir, benchname_rust)
     wasmdir = os.path.abspath(wasm_out_dir)

--- a/wasm-engines/run_benchmarks.sh
+++ b/wasm-engines/run_benchmarks.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+docker run --privileged \
+	-v $(pwd)/project:/benchrunner/project \
+	-v $(pwd)/main.py:/benchrunner/main.py \
+	-v $(pwd)/benchnativerust_prepwasm.py:/benchprep/benchnativerust_prepwasm.py \
+	-v $(pwd)/wasmfiles:/wasmfiles \
+	-v $(pwd)/benchmark_results_data:/benchmark_results_data \
+	-v $(pwd)/nanodurationpy.py:/benchprep/nanodurationpy.py \
+	-v $(pwd)/rust-code:/benchprep/rust-code \
+	-v $(pwd)/inputvectors:/benchprep/inputvectors \
+	-v $(pwd)/benchmeteredstandalone.sh:/benchprep/benchmeteredstandalone.sh \
+	-v $(pwd)/bench_wasm_and_native.sh:/benchprep/bench_wasm_and_native.sh \
+--security-opt seccomp=$(pwd)/dockerseccompprofile.json -it wasm-engines bash /benchprep/bench_wasm_and_native.sh


### PR DESCRIPTION
Rebased on top of (but does not strictly depend on): https://github.com/ewasm/benchmarking/pull/34