### PR TITLE
Clone from the ewasm-benchmarking organization

### DIFF
--- a/evm/cita-vm/Dockerfile
+++ b/evm/cita-vm/Dockerfile
@@ -22,10 +22,10 @@ RUN apt-get update \
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y && . $HOME/.cargo/env
 ENV PATH=/root/.cargo/bin:$PATH
-RUN rustup default nightly-2019-01-15
+RUN rustup default nightly-2020-06-05
 
 # install cita-vm
-RUN git clone --single-branch --branch evm-bencher https://github.com/cdetrio/cita-vm
+RUN git clone --single-branch --branch evm-bencher https://github.com/ewasm-benchmarking/cita-vm
 RUN cd cita-vm/evmbin && cargo build --release
 
 # install python modules needed for benchmarking script

--- a/evm/evmone/Dockerfile
+++ b/evm/evmone/Dockerfile
@@ -23,7 +23,7 @@ RUN pip3 install durationpy jinja2 pandas
 
 # install evmone
 WORKDIR /root
-RUN git clone --recursive --single-branch --branch bench-evm-codes https://github.com/cdetrio/evmone
+RUN git clone --recursive --single-branch --branch bench-evm-codes https://github.com/ewasm-benchmarking/evmone
 RUN cd evmone && mkdir build
 RUN cd evmone/build && cmake .. -DEVMONE_TESTING=ON
 RUN cd evmone/build && cmake --build . -- -j

--- a/evm/geth/Dockerfile
+++ b/evm/geth/Dockerfile
@@ -25,9 +25,9 @@ RUN pip3 install durationpy jinja2 pandas
 RUN add-apt-repository ppa:longsleep/golang-backports && apt-get update && apt-get install -y golang-go
 
 # install geth
-RUN go get -u -v github.com/ethereum/go-ethereum
-RUN cd /root/go/src/github.com/ethereum/go-ethereum && git pull origin master && make all
-RUN ln -s /root/go/src/github.com/ethereum/go-ethereum /go-ethereum
+RUN go get -u -v github.com/ewasm-benchmarking/go-ethereum
+RUN cd /root/go/src/github.com/ewasm-benchmarking/go-ethereum && git pull origin v1.9.14-benchmarking && make all
+RUN ln -s /root/go/src/github.com/ewasm-benchmarking/go-ethereum /go-ethereum
 
 WORKDIR /
 RUN mkdir -p /evmraceresults

--- a/evm/parity/Dockerfile
+++ b/evm/parity/Dockerfile
@@ -32,7 +32,7 @@ RUN rustup default nightly-2019-01-15
 RUN rustup target add wasm32-unknown-unknown
 
 # install parity-evm
-RUN git clone --recursive --single-branch --branch evm-code-bencher https://github.com/cdetrio/parity
+RUN git clone --recursive --single-branch --branch evm-code-bencher https://github.com/ewasm-benchmarking/openethereum parity
 RUN cd parity/evmbin && cargo build --release
 
 # deps required to build full parity for native precompile benchmarks

--- a/scout-engines/Dockerfile
+++ b/scout-engines/Dockerfile
@@ -62,68 +62,68 @@ RUN cd google-benchmark/build && make install
 
 
 # wabt branch for websnark-bn128 slowhost slowmont (no superops)
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-slowhost-slowmont https://github.com/ewasm/wabt.git wabt-bn128-websnark-slowmont-slowhost
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-slowhost-slowmont https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-websnark-slowmont-slowhost
 RUN cd wabt-bn128-websnark-slowmont-slowhost && make clang-release
 # could also use `make gcc-release`, but gcc is slower than clang
 
 # wabt branch for websnark-bn128 slowhost slowmont superops
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-slowhost-slowmont-superops https://github.com/ewasm/wabt.git wabt-bn128-websnark-slowmont-slowhost-superops
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-slowhost-slowmont-superops https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-websnark-slowmont-slowhost-superops
 RUN cd wabt-bn128-websnark-slowmont-slowhost-superops && make clang-release
 
 # wabt branch for websnark-bn128 fasthost slowmont superops
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-fasthost-slowmont-superops https://github.com/ewasm/wabt.git wabt-bn128-websnark-slowmont-fasthost-superops
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-fasthost-slowmont-superops https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-websnark-slowmont-fasthost-superops
 RUN cd wabt-bn128-websnark-slowmont-fasthost-superops && make clang-release
 
 # wabt branch for websnark-bn128 fasthost fastmont superops
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-fasthost-fastmont-superops https://github.com/ewasm/wabt.git wabt-bn128-websnark-fastmont-fasthost-superops
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-fasthost-fastmont-superops https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-websnark-fastmont-fasthost-superops
 RUN cd wabt-bn128-websnark-fastmont-fasthost-superops && make clang-release
 
 # wabt branch for websnark-bn128 fasthost fastmont (no superops)
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-fasthost-fastmont https://github.com/ewasm/wabt.git wabt-bn128-websnark-fastmont-fasthost
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-websnark-fasthost-fastmont https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-websnark-fastmont-fasthost
 RUN cd wabt-bn128-websnark-fastmont-fasthost && make clang-release
 
 
 
 # the branch scout-bignums-daiquiri-withdraw is the same as scout-bignum-hostfuncs, but with a hardcoded prestate returned by eth2_loadPrestateRoot().
 # the ecpairing-zkrollup-bn128 scout benchmark doesn't load the prestate, so this branch is compatible with that and with the daiquiri-withdraw benchmark
-RUN git clone --recursive --single-branch --branch scout-bignums-daiquiri-withdraw https://github.com/ewasm/wabt.git wabt-bn128
+RUN git clone --recursive --single-branch --branch scout-bignums-daiquiri-withdraw https://github.com/ewasm-benchmarking/wabt.git wabt-bn128
 RUN cd wabt-bn128 && make clang-release
 
 
 
 # install wabt with bignum host fuctions for secp256k1 (no superops)
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-secp256k1 https://github.com/ewasm/wabt.git wabt-secp
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-secp256k1 https://github.com/ewasm-benchmarking/wabt.git wabt-secp
 RUN cd wabt-secp && make clang-release
 
 
 
 # install wabt branch with host functions for biturbo/turbo-token-realistic (this branch has superops, but is a bit messy)
-RUN git clone --recursive --single-branch --branch scout-for-biturbo-token https://github.com/ewasm/wabt.git wabt-biturbo
+RUN git clone --recursive --single-branch --branch scout-for-biturbo-token https://github.com/ewasm-benchmarking/wabt.git wabt-biturbo
 RUN cd wabt-biturbo && make clang-release
 
 # turbo-token wabt branch without superops
-RUN git clone --recursive --single-branch --branch scout-biturbo-no-superops https://github.com/ewasm/wabt.git wabt-biturbo-no-superops
+RUN git clone --recursive --single-branch --branch scout-biturbo-no-superops https://github.com/ewasm-benchmarking/wabt.git wabt-biturbo-no-superops
 RUN cd wabt-biturbo-no-superops && make clang-release
 
 
 
 # wabt branch for rollup.rs bignums slowmont slowhost
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-slowmont-slowhost https://github.com/ewasm/wabt.git wabt-bn128-rolluprs-slowmont-slowhost
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-slowmont-slowhost https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-rolluprs-slowmont-slowhost
 RUN cd wabt-bn128-rolluprs-slowmont-slowhost && make clang-release
 
 # wabt branch for rollup.rs bignums slowmont slowhost superops
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-slowmont-slowhost-superops https://github.com/ewasm/wabt.git wabt-bn128-rolluprs-slowmont-slowhost-superops
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-slowmont-slowhost-superops https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-rolluprs-slowmont-slowhost-superops
 RUN cd wabt-bn128-rolluprs-slowmont-slowhost-superops && make clang-release
 
 
 # wabt branch for rollup.rs with bignums slowmont fasthost superops
 # not much diff on rollup.rs, but show anyway
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-slowmont-fasthost-superops https://github.com/ewasm/wabt.git wabt-bn128-rolluprs-slowmont-fasthost-superops
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-slowmont-fasthost-superops https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-rolluprs-slowmont-fasthost-superops
 RUN cd wabt-bn128-rolluprs-slowmont-fasthost-superops && make clang-release
 
 # wabt branch for rollup.rs with bignum fastmont fasthost superops
 # not much diff on rollup.rs, but show anyway
-RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-fastmont-fasthost-superops https://github.com/ewasm/wabt.git wabt-bn128-rolluprs-fastmont-fasthost-superops
+RUN git clone --recursive --single-branch --branch scout-bignum-hostfuncs-bn128-rolluprs-fastmont-fasthost-superops https://github.com/ewasm-benchmarking/wabt.git wabt-bn128-rolluprs-fastmont-fasthost-superops
 RUN cd wabt-bn128-rolluprs-fastmont-fasthost-superops && make clang-release
 
 # only missing rollup.rs fastmont slowhost superops
@@ -144,67 +144,42 @@ RUN cd wabt-bn128-rolluprs-fastmont-fasthost-superops && make clang-release
 #RUN cd wabt-bn128-rolluprs-fastmont-slowhost && make clang-release
 
 
-# wabt branch for wasmsnark bls12
-RUN git clone --recursive --single-branch --branch bls12-bignums-fastmont-superops https://github.com/ewasm/wabt.git wabt-bls12-fastmont-fasthost-superops
-RUN cd wabt-bls12-fastmont-fasthost-superops && make clang-release
-
-# for the "host func variations" (i.e. using host funcs for [f1m_mul], [f1m_mul, f1m_add], [f1m_mul, f1m_add, f1m_sub], ...)
-# we need to use the no-superops wabt branch because there's a bug in superops triggered by the wasm code in one of {int_mul, int_sub, int_add, int_div} (I can't remember which)
-RUN git clone --recursive --single-branch --branch bls12-bignums-fasthost-fastmont-no-superops https://github.com/ewasm/wabt.git wabt-bls12-bignums-fasthost-fastmont-no-superops
-RUN cd wabt-bls12-bignums-fasthost-fastmont-no-superops && make clang-release
-
-
-# Note: these scout.cpp branches are disabled because the wabt version scout.cpp is based on is slower than the wabt version used in the `github.com/ewasm/wabt` branches
-# We don't know why scout.cpp is slower than `github.com/ewasm/wabt`, in theory it should be the same speed.
-# scout.cpp is based on a later version of wabt (wabt-2020), `github.com/ewasm/wabt` is an older version (wabt-2018).
-# There might be a performance regression in later versions of wabt.
 
 # install scout.cpp branch with bignum host functions for bn128
-#RUN git clone --recursive --single-branch --branch bignum-host-funcs https://github.com/cdetrio/scout.cpp.git scoutcpp-bn128
+RUN git clone --recursive --single-branch --branch bignum-host-funcs https://github.com/ewasm-benchmarking/scout_wabt.cpp.git scoutcpp-bn128
 # commit 7afd65dda637436151d69fb47d22034c2ecfea45 (fix interleaved)
-#RUN cd scoutcpp-bn128 && mkdir build && cd build && cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make
+RUN cd scoutcpp-bn128 && mkdir build && cd build && cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make
 
 # install scout.cpp branch with bignum host functions for secp256k1
-#RUN git clone --recursive --single-branch --branch bignum-hostfuncs-secp256k1 https://github.com/cdetrio/scout.cpp.git scoutcpp-secp
-#RUN cd scoutcpp-secp && mkdir build && cd build && cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make
+RUN git clone --recursive --single-branch --branch bignum-hostfuncs-secp256k1 https://github.com/ewasm-benchmarking/scout_wabt.cpp.git scoutcpp-secp
+RUN cd scoutcpp-secp && mkdir build && cd build && cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make
 
 # install scout.cpp branch for rollup.rs
-#RUN git clone --recursive --single-branch --branch bignum-hostfuncs-bn128-rolluprs https://github.com/cdetrio/scout.cpp.git scoutcpp-bn128-rolluprs
-#RUN cd scoutcpp-bn128-rolluprs && mkdir build && cd build && cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make
+RUN git clone --recursive --single-branch --branch bignum-hostfuncs-bn128-rolluprs https://github.com/ewasm-benchmarking/scout_wabt.cpp.git scoutcpp-bn128-rolluprs
+RUN cd scoutcpp-bn128-rolluprs && mkdir build && cd build && cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .. && make
 
 
 WORKDIR /scoutyamls
 
 # clone scout.ts branch with secp-sig-verify
-RUN git clone https://github.com/ewasm/scout.ts.git --single-branch --branch secp-sig-verify scout.ts-secp
+RUN git clone https://github.com/ewasm-benchmarking/scout.ts.git --single-branch --branch secp-sig-verify scout.ts-secp
 RUN cd scout.ts-secp && npm install && npm run build
 
 # clone scout.ts branch with bn128-pairing
-RUN git clone https://github.com/ewasm/scout.ts.git --single-branch --branch bn128-pairing scout.ts-bn128
+RUN git clone https://github.com/ewasm-benchmarking/scout.ts.git --single-branch --branch bn128-pairing scout.ts-bn128
 RUN cd scout.ts-bn128 && npm install && npm run build
 
 # clone daiquri branch
-RUN git clone https://github.com/cdetrio/daiquiri.git --single-branch --branch scout-benchreport-withdraw daiquiri
+RUN git clone https://github.com/ewasm-benchmarking/daiquiri.git --single-branch --branch scout-benchreport-withdraw daiquiri
 RUN cd daiquiri && npm install && npm run build
 
 # clone biturbo branch
-RUN git clone https://github.com/ewasm/biturbo.git --single-branch --branch scout-benchreport biturbo
+RUN git clone https://github.com/ewasm-benchmarking/biturbo.git --single-branch --branch scout-benchreport biturbo
 RUN cd biturbo && npm install && npm run build
 RUN cd biturbo && npm run token:relayer:realistic && npm run token:build
 
-# TODO: for the bls12 branch (and probably the other scout.ts branches), doing `npm run build` in the scout.ts dir
-# will build the scout.ts runner. In `scout.ts/assembly/bls12-pairing`, `npm run build` will build the wasm file.
-# Building the wasm file is currently fragile, and won't work if the right `asc` version isn't installed.
-# Need to investigate what the right `asc` version is, or fix so it builds on later asc versions.
-# For now, the wasm builds are pushed to the repo. The `npm run build` below only builds the scout.ts runner.
-
-# clone scout.ts branch with bls12
-RUN git clone https://github.com/ewasm/scout.ts.git --single-branch --branch bls12-bench-report scout.ts-bls12
-RUN cd scout.ts-bls12 && npm install && npm run build
-
-
 # clone c_ewasm_contracts (commit 29356a22ea38cf2f1bbab05a4b8974822834f4e7)
-RUN git clone https://github.com/poemm/C_ewasm_contracts.git --single-branch --branch master C_ewasm_contracts
+RUN git clone https://github.com/ewasm-benchmarking/C_ewasm_contracts.git --single-branch --branch master C_ewasm_contracts
 # remove some tests we don't want
 RUN cd C_ewasm_contracts/tests && rm ecrecover.yaml ecrecover_trezor.yaml ed25519verify.yaml helloworld.yaml
 
@@ -221,26 +196,20 @@ RUN rustup target add wasm32-unknown-unknown
 
 
 # clone rollup.rs native
-RUN git clone https://github.com/cdetrio/rollup.rs --single-branch --branch benchreport-rust-native rollup-rs-native
+RUN git clone https://github.com/ewasm-benchmarking/rollup.rs --single-branch --branch benchreport-rust-native rollup-rs-native
 RUN cd rollup-rs-native && cargo build --release
 
 # clone rollup.rs scout no bignums
-RUN git clone https://github.com/cdetrio/rollup.rs --single-branch --branch benchreport-scout-no-bignums rollup-rs-no-bignums
+RUN git clone https://github.com/ewasm-benchmarking/rollup.rs --single-branch --branch benchreport-scout-no-bignums rollup-rs-no-bignums
 RUN cd rollup-rs-no-bignums && cargo build --lib --release
 RUN cd /scoutyamls/scout.ts-bn128 && mkdir -p target/wasm32-unknown-unknown/release
 RUN cd /scoutyamls/scout.ts-bn128 && cp /scoutyamls/rollup-rs-no-bignums/target/wasm32-unknown-unknown/release/rollup_rs_wasm.wasm ./target/wasm32-unknown-unknown/release/rollup_rs_wasm.wasm
 RUN cp /scoutyamls/rollup-rs-no-bignums/rolluprs.yaml /scoutyamls/scout.ts-bn128/rolluprs.yaml
 
 # clone rollup.rs for scout with bignums
-RUN git clone https://github.com/cdetrio/rollup.rs --single-branch --branch benchreport-scout-bignums rollup-rs-with-bignums
+RUN git clone https://github.com/ewasm-benchmarking/rollup.rs --single-branch --branch benchreport-scout-bignums rollup-rs-with-bignums
 RUN cd rollup-rs-with-bignums && cargo build --lib --release
 
-RUN rustup default nightly-2020-04-23
-
-# clone eip1962-bls12.rs native
-RUN git clone --single-branch --branch dev https://github.com/jwasinger/eip1962-bls12-381-bench.git eip1962-bls12-rs-native
-RUN cd eip1962-bls12-rs-native && git submodule update --init
-RUN cd eip1962-bls12-rs-native && cargo build --release
 
 # copy the python script to run the benchmarks
 RUN mkdir /benchscript


### PR DESCRIPTION
~~Depends on https://github.com/ewasm/benchmarking/pull/43~~
~~Also depends on Docker image `jwasinger/bench:1.0`.~~

Changes EVM Engine and Scout Engines Dockerfiles  to clone from the `ewasm-benchmarking` repositories.