### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,22 @@
-all: notebook
+all: evm_precompiles evm_engines wasm_engines notebook
+
+build_docker_images:
+	cd evm/geth && docker build . -t geth-bench
+	cd evm/parity && docker build . -t parity-bench
+	cd evm/evmone && docker build . -t evmone-bench
+	cd evm/cita-vm && docker build . -t cita-vm-bench
+	cd wasm-engines && ./build_engines.sh
+
+evm_precompiles: build_docker_images
+	cd evm && ./scripts/run_precompiles_bench.sh geth
+	cd evm && ./scripts/run_precompiles_bench.sh parity
+
+evm_engines: build_docker_images
+	cd evm && ./scripts/run_bench.sh
+
+wasm_engines:
+	docker pull ewasm/bench:1.0
+	cd wasm-engines && ./run_benchmarks.sh
 
 # Default timeout is 30 seconds, but our cells are quite big, increase it to 120 seconds.
 # More info: https://github.com/jupyter/nbconvert/issues/256#issuecomment-188405852


### PR DESCRIPTION
Makefile to generate the charts based on the python notebook, other options are available but not fully tested.

This PR also deletes the no longer needed python script that were previously used to generate the charts.

Part of #51.