### PR TITLE
Exit gracefully in node-timer.js if file is missing

### DIFF
--- a/wasm-engines/node-timer.js
+++ b/wasm-engines/node-timer.js
@@ -10,39 +10,40 @@ var wasmfile = args[0];
 
 console.log('args:', args);
 
-console.log('---- reading wasm file..')
+console.log('---- reading wasm file..');
 const readAsBinary = filename => {
-if (typeof process === 'object' && typeof require === 'function') {
+  if (typeof process === 'object' && typeof require === 'function') {
     const binary = require('fs').readFileSync(filename);
     return !binary.buffer ? new Uint8Array(binary) : binary;
-} else
+  } else {
     return typeof readbuffer === 'function'
-        ? new Uint8Array(readbuffer(filename))
-        : read(filename, 'binary');
+      ? new Uint8Array(readbuffer(filename))
+      : read(filename, 'binary');
+  }
 };
 
-const wasmBytes = readAsBinary(wasmfile)
+const wasmBytes = readAsBinary(wasmfile);
 
-console.log('---- wasm file read.')
+console.log('---- wasm file read.');
 
 const imports = {
-    env: {}
+  env: {}
 };
 
-imports.env.memory = new WebAssembly.Memory({ initial: 10 })
+imports.env.memory = new WebAssembly.Memory({ initial: 10 });
 
 console.time('instantiate');
 WebAssembly.instantiate(wasmBytes, imports)
-  .then(r => {
+  .then(result => {
     console.timeEnd('instantiate');
     console.log('---- calling main...')
     console.time('run-main');
     try {
-      const syncReturn = r.instance.exports.main();
+      const syncReturn = result.instance.exports.main();
       console.timeEnd('run-main');
       console.log('---- wasm returns:', syncReturn);
     } catch (e) {
       console.timeEnd('run-main');
-      console.log('caught error:', e)
+      console.log('caught error:', e);
     }
   });

--- a/wasm-engines/node-timer.js
+++ b/wasm-engines/node-timer.js
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+if (process.argv.length < 3) {
+  console.log('Missing argument (wasm file)');
+  process.exit(1);
+}
+
 var args = process.argv.slice(2);
 var wasmfile = args[0];
 


### PR DESCRIPTION
```shell
$ ./node-timer.js
Missing argument (wasm file)

$ ./node-timer.js wasmfiles/ecpairing.wasm 
args: [ 'wasmfiles/ecpairing.wasm' ]
---- reading wasm file..
---- wasm file read.
instantiate: 95.758ms
---- calling main...
run-main: 73.939ms
---- wasm returns: undefined
```