### PR TITLE
Change parity to v2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ make notebook
 
 ## EVM engine versions
 
-- cita-vm: 6fbc4196
+- cita-vm: v0.1.3 (May 2019)
 - evmone: 94f4e827 (closest to v0.1.0)
 - geth: v1.9.14 (+ go 1.11)
 - parity/openethereum: ecbafb23 (closest to v2.5.2)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ $ make notebook
 - cita-vm: v0.1.3 (May 2019)
 - evmone: 94f4e827 (closest to v0.1.0)
 - geth: v1.9.14 (+ go 1.11)
-- parity/openethereum: ecbafb23 (closest to v2.5.2)
+- parity/openethereum: v2.5.1 (May 2019)
 
 ## WebAssembly engine versions
 

--- a/evm/cita-vm/Dockerfile
+++ b/evm/cita-vm/Dockerfile
@@ -25,9 +25,8 @@ ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup default nightly-2020-06-05
 
 # install cita-vm
-RUN git clone --single-branch --branch evm-bencher https://github.com/ewasm-benchmarking/cita-vm
+RUN git clone --single-branch --branch v0.1.3-benchmarking https://github.com/ewasm-benchmarking/cita-vm
 RUN cd cita-vm/evmbin && cargo build --release
 
 # install python modules needed for benchmarking script
 RUN pip3 install durationpy jinja2 pandas
-

--- a/evm/parity/Dockerfile
+++ b/evm/parity/Dockerfile
@@ -32,7 +32,7 @@ RUN rustup default nightly-2019-01-15
 RUN rustup target add wasm32-unknown-unknown
 
 # install parity-evm
-RUN git clone --recursive --single-branch --branch evm-code-bencher https://github.com/ewasm-benchmarking/openethereum parity
+RUN git clone --recursive --single-branch --branch v2.5.1-benchmarking https://github.com/ewasm-benchmarking/openethereum parity
 RUN cd parity/evmbin && cargo build --release
 
 # deps required to build full parity for native precompile benchmarks


### PR DESCRIPTION
Turned out parity is actually based on a release!

Part of #41.

Similarly to #73 this should not result in any kind of change.