### PR TITLE
Upgrade wagon to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ make notebook
 - ssvm: v0.6.0
 - v8 (node.js): v11.10.0
 - wabt: 04fe0c41 (closest to v1.0.9)
-- wagon: e9f4420c (closest to v0.4.0)
+- wagon: v0.4.0 (March 2019)
 - wamr: 130d7d07 (closest to WAMR-02-18-2020)
 - wasm3: v0.4.7
 - wasmi: v0.4.4

--- a/wasm-engines/docker/wagon.Dockerfile
+++ b/wasm-engines/docker/wagon.Dockerfile
@@ -6,7 +6,7 @@ LABEL version="1"
 LABEL description="Ewasm benchmarking (wagon)"
 
 # install wagon
-RUN git clone --single-branch --branch bench-times https://github.com/ewasm-benchmarking/wagon && \
+RUN git clone --single-branch --branch v0.4.0-benchmarking https://github.com/ewasm-benchmarking/wagon && \
     cd wagon/cmd/wasm-run && go build
 
 FROM ewasm/bench-build-base:1


### PR DESCRIPTION
This adds 2 commits (we were 2 commits behind): it removed some special cases from leb128 so I expect some speed difference, and dropped go 1.9.x support from CI, but we are/were building with go 1.11.x.

Part of #41.