### PR TITLE
Fix wasm-engines Docker image build prevented by stale package links

### DIFF
--- a/wasm-engines/docker/wasm-engines-bench.Dockerfile
+++ b/wasm-engines/docker/wasm-engines-bench.Dockerfile
@@ -21,7 +21,7 @@ LABEL description="Benchmarking environment for Ewasm benchmarking"
 RUN pip3 install jinja2 pandas click durationpy
 
 # install JRE for asmble
-RUN apt install -y openjdk-8-jre
+RUN apt update -y && apt install -y openjdk-8-jre
 ENV JAVA_VER 8
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 


### PR DESCRIPTION
The bench environment image will get built more often than the base and engine images.  `apt update -y` to prevent stale package links from the base image from breaking the bench environment image build.