### PR TITLE
Clean out build artifacts from notebook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,6 @@ benchmark: benchmark_scout_engines benchmark_wasm_engines benchmark_evm_engines 
 # More info: https://github.com/jupyter/nbconvert/issues/256#issuecomment-188405852
 # TODO: upgrade to newer nbconvert which sets the timeout to off by default
 notebook:
-	cd notebooks && jupyter nbconvert --execute --ExecutePreprocessor.timeout=120 --to notebook --inplace wasm-engines.ipynb
+	cd notebooks && \
+	jupyter nbconvert --execute --ExecutePreprocessor.timeout=120 --to notebook --inplace wasm-engines.ipynb && \
+	python3 -m nbconvert --ClearOutputPreprocessor.enabled=True --inplace wasm-engines.ipynb # delete some cruft from the notebook to make it more VCS-friendly 

--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,6 @@ jobs:
         name: Rebuild notebook
         command: |
           make notebook
-          # Ignore differences in the notebook
-          git checkout -f notebooks/wasm-engines.ipynb
           # Ensures the generated images are matching
           git diff --color --exit-code
 


### PR DESCRIPTION
Cleans out data created during the execution of a notebook (images embedded in the notebook, execution output, etc.).

This should make the notebook more git-friendly.